### PR TITLE
Fixing line breaks

### DIFF
--- a/comskip.ini
+++ b/comskip.ini
@@ -24,7 +24,8 @@ logo_percentile=0.92
 logo_threshold=0.75 
 punish_no_logo=1 
 aggressive_logo_rejection=0 
-connect_blocks_with_logo=1 logo_filter=0 
+connect_blocks_with_logo=1 
+logo_filter=0 
 cut_on_ar_change=1 
 delete_show_after_last_commercial=0 
 delete_show_before_or_after_current=0 
@@ -68,8 +69,7 @@ live_tv=0
 live_tv_retries=4 
 dvrms_live_tv_retries=300 
 standoff=0 
-cuttermaran_options="cut=\"true\" unattended=\"true\" 
-muxResult=\"false\" snapToCutPoints=\"true\" closeApp=\"true\"" 
+cuttermaran_options="cut=\"true\" unattended=\"true\" muxResult=\"false\" snapToCutPoints=\"true\" closeApp=\"true\"" 
 mpeg2schnitt_options="mpeg2schnitt.exe /S /E /R25 /Z %2 %1" 
 avisynth_options="LoadPlugin(\"MPEG2Dec3.dll\") \nMPEG2Source(\"%s\")\n" 
 dvrcut_options="dvrcut \"%s.dvr-ms\" \"%s_clean.dvr-ms\" " 


### PR DESCRIPTION
connect_blocks_with_logo=1 logo_filter=0 lines doubled up and the cuttermaran_options= line split in original. I have fixed the line spacing on theses.

This fixes some problems I pointed out in [https://emby.media/community/index.php?/topic/49900-automated-commercial-removal-from-tv-recordings/page-1#entry500130](https://emby.media/community/index.php?/topic/49900-automated-commercial-removal-from-tv-recordings/page-1#entry500130 )